### PR TITLE
Mock underlying fileystem writes

### DIFF
--- a/tests/TestCase/File/Writer/DefaultWriterTest.php
+++ b/tests/TestCase/File/Writer/DefaultWriterTest.php
@@ -33,7 +33,13 @@ class DefaultWriterTest extends TestCase
                 }
             ]
         ];
-        $this->writer = new DefaultWriter($this->table, $this->entity, $this->data, $this->field, $this->settings);
+        $this->writer = new DefaultWriter(
+            $this->table,
+            $this->entity,
+            $this->data,
+            $this->field,
+            $this->settings
+        );
 
         $this->vfs = new Vfs;
         mkdir($this->vfs->path('/tmp'));
@@ -59,16 +65,19 @@ class DefaultWriterTest extends TestCase
 
     public function testDelete()
     {
-        $writer = $this->getMock('Josegonzalez\Upload\File\Writer\DefaultWriter', ['delete'], [$this->table, $this->entity, $this->data, $this->field, $this->settings]);
-        $writer->expects($this->any())->method('delete')->will($this->returnValue([true]));
+        $filesystem = $this->getMock('League\Flysystem\FilesystemInterface');
+        $filesystem->expects($this->at(0))->method('delete')->will($this->returnValue(true));
+        $filesystem->expects($this->at(1))->method('delete')->will($this->returnValue(false));
+        $writer = $this->getMock('Josegonzalez\Upload\File\Writer\DefaultWriter', ['getFilesystem'], [$this->table, $this->entity, $this->data, $this->field, $this->settings]);
+        $writer->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
+
+        $this->assertEquals([], $writer->delete([]));
         $this->assertEquals([true], $writer->delete([
-            $this->vfs->path('existing-file.txt')
+            $this->vfs->path('/tmp/tempfile')
         ]));
 
-        $writer = $this->getMock('Josegonzalez\Upload\File\Writer\DefaultWriter', ['delete'], [$this->table, $this->entity, $this->data, $this->field, $this->settings]);
-        $writer->expects($this->any())->method('delete')->will($this->returnValue([false]));
         $this->assertEquals([false], $writer->delete([
-            $this->vfs->path('unexisting-file.txt')
+            $this->vfs->path('/tmp/invalid.txt')
         ]));
     }
 


### PR DESCRIPTION
Rather than mocking the DefaultWriter, we mock the responses from the filesystem to say that a delete has succeeded or failed. This will suffice for testing the proper responses from DefaultWriter::delete()

Yo dawg, I heard you like pull requests, so I put a pull request in your pull request, so you can pull request while I pull request.